### PR TITLE
Fix publishing missing types

### DIFF
--- a/packages/eth-rpc-cache/package.json
+++ b/packages/eth-rpc-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-rpc-cache",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A simple cache for Ethereum RPC requests",
   "keywords": [
     "cache",
@@ -38,5 +38,6 @@
     "ts-node": "10.9.2",
     "typescript": "5.4.5"
   },
-  "type": "module"
+  "type": "module",
+  "types": "dist/index.d.ts"
 }

--- a/packages/eth-rpc-cache/tsconfig.json
+++ b/packages/eth-rpc-cache/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "allowJs": false,
     "baseUrl": "./src",
+    "declaration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,


### PR DESCRIPTION
When installing the package, types are missing (so we can't import it). This PR should fix that. I tested it using `npm link` and it worked